### PR TITLE
Add /liveness endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -83,9 +83,13 @@ export function createApp({
 		initOAuth: {},
 	})
 
-	fastify.get('/', (req, res) => {
-		res.redirect(`${basePath}/documentation/static/index.html`)
-	})
+        fastify.get('/', (req, res) => {
+                res.redirect(`${basePath}/documentation/static/index.html`)
+        })
+
+        fastify.get('/liveness', async (_req, res) => {
+                res.status(200).send('OK')
+        })
 
 	fastify.register(routes)
 

--- a/src/tests/liveness.test.ts
+++ b/src/tests/liveness.test.ts
@@ -1,0 +1,12 @@
+import { startTestServer } from './startTestServer.js'
+
+const testServer = await startTestServer()
+
+afterAll(async () => testServer.close())
+
+test('/liveness', async () => {
+        const response = await testServer.fetch('liveness')
+        expect(response.status).toBe(200)
+        const text = await response.text()
+        expect(text).toBe('OK')
+})


### PR DESCRIPTION
## Summary
- add liveness route returning `OK`
- test the liveness check

## Testing
- `pnpm run test` *(fails: cannot download pnpm packages)*

------
https://chatgpt.com/codex/tasks/task_e_6875f1cde314832a8a0ad172784bdcbf